### PR TITLE
waveColor setter method implemented

### DIFF
--- a/WXWaveView-demo/WXWaveView/WXWaveView.m
+++ b/WXWaveView-demo/WXWaveView/WXWaveView.m
@@ -52,6 +52,14 @@
     _waveColor = [UIColor whiteColor];
 }
 
+//MARK:
+//      if someone tries to updated wave color without `wave` method calling.
+//      For example, while someone using WXWaveView in a UICollectionViewCell, and they just want updating wave color for each cell
+- (void)setWaveColor:(UIColor *)waveColor {
+    _waveColor = waveColor;
+    self.waveShapeLayer.fillColor = self.waveColor.CGColor;
+}
+
 - (BOOL)wave {
     if (self.waveShapeLayer.path) {
         return NO;


### PR DESCRIPTION
I'm using WXWaveView in a UICollectionViewCell, and I just want to update the wave color for each cell without calling `wave` method.  
As collectionView reuses cells, wave color was not updating because WXWaveView's instance was created inside ` init coder`. So while reusing the cell wave color was not updating.  For that reason, I've added this setter method for to update wave color